### PR TITLE
Forward server env var share endpoint error to caller [SSW-1589]

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+
+	"github.com/pkg/errors"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"

--- a/api/api.go
+++ b/api/api.go
@@ -3,11 +3,10 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/pkg/errors"
 
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/retryhttp"

--- a/api/api.go
+++ b/api/api.go
@@ -80,12 +80,12 @@ func checkEnvVarShareResponse(resp *http.Response) error {
 	var respBodyJSON map[string]string
 	err = json.Unmarshal(respBody, &respBodyJSON)
 	if err != nil {
-		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", string(respBody))
+		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", string(respBody)))
 		return respErr
 	}
 	clientRespErrMsg, isSet := respBodyJSON["error_msg"]
 	if !isSet || respBodyJSON["error_msg"] == "" {
-		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", respBodyJSON)
+		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", respBodyJSON))
 		return respErr
 	}
 	respErr = errors.New(respErr.Error() + fmt.Sprintf(", message: %s", clientRespErrMsg))

--- a/api/api.go
+++ b/api/api.go
@@ -80,10 +80,12 @@ func checkEnvVarShareResponse(resp *http.Response) error {
 	var respBodyJSON map[string]string
 	err = json.Unmarshal(respBody, &respBodyJSON)
 	if err != nil {
+		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", string(respBody))
 		return respErr
 	}
 	clientRespErrMsg, isSet := respBodyJSON["error_msg"]
 	if !isSet || respBodyJSON["error_msg"] == "" {
+		respErr = errors.New(respErr.Error() + fmt.Sprintf(", response body: %s", respBodyJSON)
 		return respErr
 	}
 	respErr = errors.New(respErr.Error() + fmt.Sprintf(", message: %s", clientRespErrMsg))

--- a/api/api.go
+++ b/api/api.go
@@ -70,5 +70,21 @@ func checkEnvVarShareResponse(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
-	return fmt.Errorf("request to %s failed: status code should be 2xx (%d)", resp.Request.URL, resp.StatusCode)
+	respErr := fmt.Errorf("request to %s failed: status code should be 2xx (%d)", resp.Request.URL, resp.StatusCode)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return respErr
+	}
+	var respBodyJSON map[string]string
+	err = json.Unmarshal(respBody, &respBodyJSON)
+	if err != nil {
+		return respErr
+	}
+	clientRespErrMsg, isSet := respBodyJSON["error_msg"]
+	if !isSet || respBodyJSON["error_msg"] == "" {
+		return respErr
+	}
+	respErr = errors.New(respErr.Error() + fmt.Sprintf(", message: %s", clientRespErrMsg))
+
+	return respErr
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -86,7 +86,10 @@ func TestBitriseClient_ShareEnvVars_FailingRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		serverCalled = true
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error_msg":"some error"}`))
+		_, err := w.Write([]byte(`{"error_msg":"some error"}`))
+		if err != nil {
+			return
+		}
 	}))
 	defer server.Close()
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -86,12 +86,13 @@ func TestBitriseClient_ShareEnvVars_FailingRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		serverCalled = true
 		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error_msg":"some error"}`))
 	}))
 	defer server.Close()
 
 	c := NewBitriseClient(server.URL, buildSlug, apiToken, log.NewLogger())
 	err := c.ShareEnvVars(envVars)
 	require.Error(t, err)
-	require.Equal(t, fmt.Sprintf("request to %s/pipeline/workflow_builds/slug/env_vars failed: status code should be 2xx (400)", server.URL), err.Error())
+	require.Equal(t, fmt.Sprintf("request to %s/pipeline/workflow_builds/slug/env_vars failed: status code should be 2xx (400), message: some error", server.URL), err.Error())
 	require.Equal(t, true, serverCalled)
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Currently the step's output does not include the error message returned by the server. This change adds that to the error output.